### PR TITLE
feat: add standalone mappings and richer HTTP mocking

### DIFF
--- a/PROPOSED_CHANGES.md
+++ b/PROPOSED_CHANGES.md
@@ -23,8 +23,8 @@ The main additions are:
 
 What changed:
 
-- Added [cmd/moxy/main.go](/Users/rahulchadgal/go/moxy/cmd/moxy/main.go)
-- Added [cmd/moxy/main_test.go](/Users/rahulchadgal/go/moxy/cmd/moxy/main_test.go)
+- Added `cmd/moxy/main.go`
+- Added `cmd/moxy/main_test.go`
 - Added CLI flags:
   - `--host`
   - `--port`
@@ -52,7 +52,7 @@ Reviewer notes:
 
 What changed:
 
-- Added [mappings.go](/Users/rahulchadgal/go/moxy/mappings.go)
+- Added `mappings.go`
 - Added mapping types:
   - `Mapping`
   - `MappingRequest`
@@ -267,8 +267,8 @@ Reviewer notes:
 
 What changed:
 
-- Expanded [mappings_test.go](/Users/rahulchadgal/go/moxy/mappings_test.go)
-- Added [cmd/moxy/main_test.go](/Users/rahulchadgal/go/moxy/cmd/moxy/main_test.go)
+- Expanded `mappings_test.go`
+- Added `cmd/moxy/main_test.go`
 
 Newly covered areas include:
 

--- a/PROPOSED_CHANGES.md
+++ b/PROPOSED_CHANGES.md
@@ -1,0 +1,335 @@
+# Proposed Changes for Review
+
+This note is meant to help the repository author review the work in this branch quickly. It focuses on what changed, why the change was made, what value it adds for Go developers, and where there may still be follow-up work.
+
+## Summary
+
+Before these changes, moxy was mainly a Go test helper built around `httptest.Server`. It already handled HTTP, HTTPS, mTLS, request matching, sequential responses, delays, timeouts, and unmatched request tracking.
+
+The work in this branch keeps that model intact, but extends it so moxy can also act like a small standalone mock server with file-based configuration and runtime control.
+
+The main additions are:
+
+- a standalone `moxy` binary
+- native JSON mappings
+- runtime admin endpoints under `/__moxy`
+- a full request journal
+- richer request matching
+- dynamic response templates
+- a few public API cleanups
+- stronger test coverage around the new surfaces
+
+## 1. Standalone Binary
+
+What changed:
+
+- Added [cmd/moxy/main.go](/Users/rahulchadgal/go/moxy/cmd/moxy/main.go)
+- Added [cmd/moxy/main_test.go](/Users/rahulchadgal/go/moxy/cmd/moxy/main_test.go)
+- Added CLI flags:
+  - `--host`
+  - `--port`
+  - `--https`
+  - `--mappings`
+  - `--verbose`
+
+Why this was added:
+
+- Earlier, moxy could only be started from Go code.
+- That worked well in tests, but made it harder to use from CI scripts, local tooling, or non-Go callers.
+
+How this helps:
+
+- A Go team can keep using `NewMockServer()` in tests.
+- The same team can also run a real mock server process during local development or CI.
+- The standalone binary reuses the same core engine as the library, so behavior stays aligned.
+
+Reviewer notes:
+
+- `main.go` was refactored slightly so the CLI flow can be tested directly.
+- The new `run(...)` and `serve(...)` helpers exist mainly to keep the CLI testable and avoid depending on `log.Fatal` in tests.
+
+## 2. Native JSON Mappings
+
+What changed:
+
+- Added [mappings.go](/Users/rahulchadgal/go/moxy/mappings.go)
+- Added mapping types:
+  - `Mapping`
+  - `MappingRequest`
+  - `MappingResponse`
+  - `BasicAuth`
+- Added:
+  - `LoadMappings(path string) error`
+  - `AddMapping(mapping Mapping) error`
+  - `Mapping.ToExpectation()`
+
+Supported request fields:
+
+- `method`
+- `path`
+- `pathPattern`
+- `headers`
+- `headerMatches`
+- `query`
+- `queryMatches`
+- `cookies`
+- `basicAuth`
+- `body`
+- `jsonBody`
+- `bodyContains`
+- `jsonFields`
+
+Supported response fields:
+
+- `status`
+- `headers`
+- `headerTemplates`
+- `body`
+- `bodyFile`
+- `bodyTemplate`
+- `delay`
+- `timeout`
+
+Also supported:
+
+- `responses` for sequential behavior
+- `times` for call limits
+- `priority` for match order
+
+Why this was added:
+
+- Earlier, all expectations had to be defined in Go code.
+- That made sharing mock behavior harder and limited the standalone server story.
+
+How this helps:
+
+- Mappings can now live in JSON fixtures.
+- Teams can load the same mappings in tests, CI, or local development.
+- Large response payloads can be stored in files instead of inline Go strings.
+
+Reviewer notes:
+
+- JSON mappings are intentionally moxy-native rather than trying to match another tool's schema.
+- `bodyFile` is resolved relative to the mapping file directory when mappings are loaded from disk, which makes fixture folders easier to move around.
+
+## 3. Admin API
+
+What changed:
+
+- Added runtime endpoints under `/__moxy`:
+  - `GET /__moxy/health`
+  - `GET /__moxy/mappings`
+  - `POST /__moxy/mappings`
+  - `DELETE /__moxy/mappings`
+  - `GET /__moxy/requests`
+  - `DELETE /__moxy/requests`
+  - `POST /__moxy/reset`
+
+Why this was added:
+
+- A standalone mock server is much more useful if mappings and request history can be inspected or reset without restarting the process.
+
+How this helps:
+
+- Tests and setup scripts can control moxy over HTTP.
+- Local debugging becomes easier because the server can reveal what it received.
+- Health checks make it simpler to use moxy in automation.
+
+Reviewer notes:
+
+- The admin API is intentionally small and moxy-specific.
+- It is not trying to be a compatibility layer for another admin API.
+
+## 4. Request Journal
+
+What changed:
+
+- Added:
+  - `RequestRecord`
+  - `RequestFilter`
+  - `GetRequests()`
+  - `ClearRequests()`
+  - `FindRequests(...)`
+  - `AllRequests()`
+
+Why this was added:
+
+- Earlier, moxy only tracked unmatched requests.
+- That was useful for debugging failures, but not for asserting on successful traffic.
+
+How this helps:
+
+- Tests can verify how many times an endpoint was called.
+- Headers, body, and query params can be inspected after the fact.
+- Retry and polling behavior are easier to validate.
+
+Reviewer notes:
+
+- Unmatched request tracking is still there.
+- The broader request journal is additive, but it does change internal bookkeeping.
+
+## 5. Better Request Matching
+
+What changed:
+
+- Added DSL methods:
+  - `WithQueryParamMatching(...)`
+  - `WithHeaderMatching(...)`
+  - `WithCookie(...)`
+  - `WithCookieMatching(...)`
+  - `WithBasicAuth(...)`
+  - `WithRequestJSONField(...)`
+  - `WithPriority(...)`
+- Added `ValueMatcher`
+
+Why this was added:
+
+- The earlier matcher handled the common basics well, but dynamic values still pushed users toward custom matchers.
+
+How this helps:
+
+- Regex-based matching is useful for auth tokens, trace IDs, and generated values.
+- Cookie and basic auth matching make session/auth flows easier to test.
+- Simple dot-path JSON matching gives field-level assertions without requiring the whole body to match exactly.
+- Priority gives predictable behavior when expectations overlap.
+
+Reviewer notes:
+
+- This is one area worth reviewing for backward-compatibility assumptions.
+- If any existing users depend on pure insertion-order matching for overlapping expectations, `Priority` may change that behavior.
+
+## 6. Dynamic Responses
+
+What changed:
+
+- Added:
+  - `AndRespondWithTemplate(...)`
+  - `WithResponseHeaderTemplate(...)`
+  - `AndRespondWithFunc(...)`
+- Added Go `text/template` rendering for response bodies and selected headers
+
+Template data includes:
+
+- method
+- path
+- path variables
+- query values
+- headers
+- cookies
+- raw body
+- parsed JSON body
+
+Why this was added:
+
+- Earlier, responses were mostly static.
+- Sequential responses helped with state-like flows, but could not easily adapt their body to the request.
+
+How this helps:
+
+- A single mapping can return different IDs or trace values based on the incoming request.
+- Response headers can echo request-derived values when needed.
+- Go users still have the custom function hook for more advanced behavior.
+
+Reviewer notes:
+
+- Template parse/render failures currently log and return a server error, which is covered by tests.
+- Invalid header templates are skipped and logged rather than breaking the whole response path.
+
+## 7. Public API Cleanup
+
+What changed:
+
+- Added:
+  - `Client()`
+  - `MTLSClient(...)`
+  - `ExpectationCallCount(...)`
+  - `NewMockServerEngine(...)`
+  - `ServerTLSConfig()`
+  - `Handler()`
+
+Why this was added:
+
+- Some docs and examples were drifting from the actual API.
+- The standalone binary also needed a way to reuse the server engine without always starting `httptest.Server`.
+
+How this helps:
+
+- The public API now matches common usage more cleanly.
+- mTLS helpers are usable from outside the package.
+- Advanced users can embed or host the moxy handler themselves.
+
+Reviewer notes:
+
+- This is mostly additive.
+- The only thing worth a quick compatibility look is whether any behavior tied to `ClearExpectations()` or match ordering should be called out more explicitly before release.
+
+## 8. Testing and Coverage
+
+What changed:
+
+- Expanded [mappings_test.go](/Users/rahulchadgal/go/moxy/mappings_test.go)
+- Added [cmd/moxy/main_test.go](/Users/rahulchadgal/go/moxy/cmd/moxy/main_test.go)
+
+Newly covered areas include:
+
+- mapping validation and error cases
+- admin API branches
+- request journal helpers
+- template success and failure paths
+- function responders
+- CLI flag parsing
+- CLI mapping load failures
+- CLI HTTP and HTTPS serve paths
+
+Verification used:
+
+```bash
+go test ./... -race -coverprofile=coverage.out -v
+go build -o /tmp/moxy-test-build ./cmd/moxy
+```
+
+Current result:
+
+- library package coverage: `89.2%`
+- CLI package coverage: `86.1%`
+- total statement coverage: `89.0%`
+
+Reviewer notes:
+
+- The test output includes some expected noisy logs.
+- Those logs come from tests that intentionally exercise unmatched requests, TLS handshake failures, bad templates, and invalid CLI flags.
+- `--help` still follows standard Go `flag` behavior and reports `flag: help requested`.
+
+## Backward-Compatibility Notes
+
+Most earlier functionality is still supported:
+
+- `NewMockServer()` and `NewMockServerWithConfig(...)`
+- HTTP, HTTPS, and mTLS support
+- the existing expectation DSL
+- path, query, header, and body matching
+- sequential responses
+- delays and timeouts
+- unmatched request tracking
+- `DefaultClient()`
+
+The main areas an author may want to review carefully are:
+
+- expectation ordering now that `Priority` exists
+- whether `ClearExpectations()` clearing loaded mappings is the right long-term behavior
+- whether the standalone admin API surface is the right minimum shape for a first release
+
+## Deferred Work
+
+These are intentionally not included in this branch:
+
+- proxy mode
+- record/playback
+- scenario/state-machine support
+- full JSONPath support
+- XML/XPath support
+- multipart matching
+- webhooks
+- advanced near-miss diagnostics
+
+The branch is aimed at improving moxy for practical Go service testing without making the project much heavier all at once.

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Stop fighting with Docker containers, flaky network calls, and manual certificat
 
 ## Features
 - Flexible request matching: HTTP method, path, headers, query params, and body.
-- Support for path variables and regular expressions.
-- Multiple response types: string, file, or custom function.
+- Support for path variables, regular expressions, cookies, basic auth, and simple JSON field matching.
+- Multiple response types: string, file, Go template, or custom function.
 - Sequential responses for repeated calls.
 - Simulate delays or timeouts.
+- Standalone `moxy` binary with JSON mapping files.
+- Runtime admin API under `/__moxy`.
+- Request journal for matched and unmatched requests.
 - MaxCalls enforcement and unmatched request tracking.
 - Thread-safe with call count tracking.
 - Middleware support and verbose logging.
@@ -26,6 +29,12 @@ Stop fighting with Docker containers, flaky network calls, and manual certificat
 
 ```bash
 go get github.com/vishav7982/moxy
+```
+
+Install the standalone binary:
+
+```bash
+go install github.com/vishav7982/moxy/cmd/moxy@latest
 ```
 
 ## Quick Start
@@ -44,6 +53,41 @@ body, _ := io.ReadAll(resp.Body)
 
 fmt.Println(string(body)) // {"message":"pong"}
 ```
+
+## Standalone Usage
+
+Run `moxy` as a local mock server and load JSON mappings from a directory:
+
+```bash
+moxy --host 127.0.0.1 --port 8080 --mappings ./mappings --verbose
+```
+
+Example mapping:
+
+```json
+{
+  "name": "get-user",
+  "request": {
+    "method": "GET",
+    "path": "/users/{id}"
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyTemplate": "{\"id\":\"{{index .PathVariables \"id\"}}\"}"
+  }
+}
+```
+
+Runtime admin endpoints are available under `/__moxy`:
+
+- `GET /__moxy/health`
+- `GET|POST|DELETE /__moxy/mappings`
+- `GET|DELETE /__moxy/requests`
+- `POST /__moxy/reset`
+
 📖 For more extensive usage examples — including https, mTLS, headers, query parameters, sequential responses, response delays, simulated server timeouts, custom responders, unmatched request handling etc. — see [mock_server_test.go](./mock_server_test.go).
 ## Why Use It ?
 Modern Go projects need reliable integration tests — but setting up real HTTP(S) servers, TLS, and mTLS is painful and slow. This library solves that by giving you an in-memory, production-like HTTP/HTTPS server that is:
@@ -60,6 +104,7 @@ No need to spin up Docker containers or mock services manually. No network flaki
 
 Define request matchers with method, path, headers, query params, and body content. Supports multiple expectations for different endpoints.
 Supports sequential responses for the same request (great for retry and polling tests).
+Supports richer matching for cookies, basic auth, regex values, and JSON fields.
 
 **✅ 4. Customizable Client & TLS Behavior**
 
@@ -72,6 +117,7 @@ Designed for parallel tests — no global state, no race conditions. Thread-safe
 **✅ 6. Clear Failure Reporting**
 
 When expectations don’t match, you get detailed logs showing the unexpected request and which expectation failed. Makes debugging test failures much faster.
+You can also inspect the request journal to see matched and unmatched requests.
 
 **✅ 7. Minimal Boilerplate**
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -100,7 +100,7 @@ ms.AddExpectation(exp)
 // Inject mock server's trusted client into GetUser
 client := ms.Client()
 
-got, err := GetUser(ms.DefaultClient(), ms.URL(), 42)
+got, err := GetUser(client, ms.URL(), 42)
 if err != nil {
 t.Fatalf("HTTPS call failed: %v", err)
 }
@@ -172,7 +172,7 @@ serverCrtFilePath := filepath.Join("testdata", "server.crt")
         AndRespondWithString(`{"id":42,"name":"Alice"}`, 200)
 	)
 	// Make request
-	resp, err := GetUser(ms.mTLSClient([]tls.Certificate{clientCert}, serverCertPool), ms.URL(), 42)
+	resp, err := GetUser(ms.MTLSClient([]tls.Certificate{clientCert}, serverCertPool), ms.URL(), 42)
     if err != nil {
      t.Fatalf("HTTPS call failed: %v", err)
     }
@@ -200,6 +200,28 @@ You can always check:
         t.Logf("Received %s %s", req.Method, req.Path)
      }
     ```
+
+**Standalone binary with JSON mappings**
+
+```bash
+moxy --host 127.0.0.1 --port 8080 --mappings ./mappings
+```
+
+Example `mappings/user.json`:
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "path": "/users/{id}"
+  },
+  "response": {
+    "status": 200,
+    "headers": { "Content-Type": "application/json" },
+    "bodyTemplate": "{\"id\":\"{{index .PathVariables \"id\"}}\"}"
+  }
+}
+```
   
 This ensures your code made the right number of HTTP calls with the right data.
 

--- a/cmd/moxy/main.go
+++ b/cmd/moxy/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/vishav7982/moxy"
+)
+
+func main() {
+	if err := run(os.Args[1:], log.Default(), serve); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(args []string, logger *log.Logger, serveFn func(*http.Server, *moxy.MockServer, bool) error) error {
+	flags := flag.NewFlagSet("moxy", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	host := flags.String("host", "127.0.0.1", "host to bind")
+	port := flags.Int("port", 8080, "port to bind")
+	https := flags.Bool("https", false, "serve HTTPS with a generated self-signed certificate")
+	mappings := flags.String("mappings", "", "directory containing moxy JSON mappings")
+	verbose := flags.Bool("verbose", false, "enable verbose request logging")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	protocol := moxy.HTTP
+	if *https {
+		protocol = moxy.HTTPS
+	}
+	mock := moxy.NewMockServerEngine(&moxy.Config{
+		Protocol:       protocol,
+		VerboseLogging: *verbose,
+	})
+	if *mappings != "" {
+		if err := mock.LoadMappings(*mappings); err != nil {
+			return fmt.Errorf("failed to load mappings: %w", err)
+		}
+	}
+
+	addr := net.JoinHostPort(*host, strconv.Itoa(*port))
+	server := &http.Server{
+		Addr:    addr,
+		Handler: mock.Handler(),
+	}
+
+	scheme := "http"
+	if *https {
+		scheme = "https"
+	}
+	logger.Printf("moxy listening on %s://%s", scheme, addr)
+	return serveFn(server, mock, *https)
+}
+
+func serve(server *http.Server, mock *moxy.MockServer, https bool) error {
+	if https {
+		listener, err := net.Listen("tcp", server.Addr)
+		if err != nil {
+			return fmt.Errorf("listen failed: %w", err)
+		}
+		tlsListener := tls.NewListener(listener, mock.ServerTLSConfig())
+		if err := server.Serve(tlsListener); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("server failed: %w", err)
+		}
+		return nil
+	}
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("server failed: %w", err)
+	}
+	return nil
+}

--- a/cmd/moxy/main_test.go
+++ b/cmd/moxy/main_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/vishav7982/moxy"
+)
+
+func TestRunBuildsHTTPServer(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	var gotAddr string
+	var gotHTTPS bool
+	var gotMock *moxy.MockServer
+	err := run([]string{"--host", "0.0.0.0", "--port", "19090", "--verbose"}, logger, func(server *http.Server, mock *moxy.MockServer, https bool) error {
+		gotAddr = server.Addr
+		gotHTTPS = https
+		gotMock = mock
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if gotAddr != "0.0.0.0:19090" {
+		t.Fatalf("expected addr 0.0.0.0:19090, got %q", gotAddr)
+	}
+	if gotHTTPS {
+		t.Fatal("expected http mode")
+	}
+	if gotMock == nil {
+		t.Fatal("expected mock server engine")
+	}
+	if !strings.Contains(buf.String(), "moxy listening on http://0.0.0.0:19090") {
+		t.Fatalf("expected log line, got %q", buf.String())
+	}
+}
+
+func TestRunBuildsHTTPSServerAndLoadsMappings(t *testing.T) {
+	dir := t.TempDir()
+	mappingPath := filepath.Join(dir, "hello.json")
+	if err := os.WriteFile(mappingPath, []byte(`{
+		"request": {"method": "GET", "path": "/hello"},
+		"response": {"status": 200, "body": "world"}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+
+	var gotHTTPS bool
+	var gotMock *moxy.MockServer
+	err := run([]string{"--https", "--mappings", dir}, logger, func(server *http.Server, mock *moxy.MockServer, https bool) error {
+		gotHTTPS = https
+		gotMock = mock
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if !gotHTTPS {
+		t.Fatal("expected https mode")
+	}
+	if gotMock == nil {
+		t.Fatal("expected mock server engine")
+	}
+	if len(gotMock.GetRequests()) != 0 {
+		t.Fatal("expected no requests during setup")
+	}
+	if !strings.Contains(buf.String(), "moxy listening on https://127.0.0.1:8080") {
+		t.Fatalf("expected https log line, got %q", buf.String())
+	}
+}
+
+func TestRunErrors(t *testing.T) {
+	logger := log.New(&bytes.Buffer{}, "", 0)
+
+	if err := run([]string{"--bad-flag"}, logger, func(server *http.Server, mock *moxy.MockServer, https bool) error {
+		return nil
+	}); err == nil {
+		t.Fatal("expected flag parse error")
+	}
+
+	if err := run([]string{"--mappings", filepath.Join(t.TempDir(), "missing")}, logger, func(server *http.Server, mock *moxy.MockServer, https bool) error {
+		return nil
+	}); err == nil || !strings.Contains(err.Error(), "failed to load mappings") {
+		t.Fatalf("expected mapping load error, got %v", err)
+	}
+
+	serveErr := errors.New("boom")
+	if err := run([]string{}, logger, func(server *http.Server, mock *moxy.MockServer, https bool) error {
+		return serveErr
+	}); !errors.Is(err, serveErr) {
+		t.Fatalf("expected serve error to bubble up, got %v", err)
+	}
+}
+
+func TestServeHTTPAndHTTPS(t *testing.T) {
+	t.Run("http", func(t *testing.T) {
+		server := &http.Server{
+			Addr: "127.0.0.1:0",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("ok"))
+			}),
+		}
+		mock := moxy.NewMockServerEngine(nil)
+
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := listener.Addr().String()
+		_ = listener.Close()
+		server.Addr = addr
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- serve(server, mock, false)
+		}()
+
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			resp, err := http.Get("http://" + addr)
+			if err == nil {
+				_, _ = ioReadAllAndClose(resp)
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("server did not start in time: %v", err)
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+
+		if err := server.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := <-errCh; err != nil {
+			t.Fatalf("serve returned error: %v", err)
+		}
+	})
+
+	t.Run("https", func(t *testing.T) {
+		mock := moxy.NewMockServerEngine(&moxy.Config{Protocol: moxy.HTTPS})
+		server := &http.Server{
+			Addr:    "127.0.0.1:0",
+			Handler: mock.Handler(),
+		}
+
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		addr := listener.Addr().String()
+		_ = listener.Close()
+		server.Addr = addr
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- serve(server, mock, true)
+		}()
+
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: mock.ServerTLSConfig(),
+			},
+		}
+
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			resp, err := client.Get("https://" + addr + "/__moxy/health")
+			if err == nil {
+				_, _ = ioReadAllAndClose(resp)
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("https server did not start in time: %v", err)
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+
+		if err := server.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := <-errCh; err != nil {
+			t.Fatalf("serve returned error: %v", err)
+		}
+	})
+}
+
+func ioReadAllAndClose(resp *http.Response) ([]byte, error) {
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}

--- a/expectations.go
+++ b/expectations.go
@@ -81,6 +81,15 @@ func (e *Expectation) WithQueryParam(key, value string) *Expectation {
 	return e
 }
 
+// WithQueryParamMatching adds a regex query parameter matcher.
+func (e *Expectation) WithQueryParamMatching(key, pattern string) *Expectation {
+	if e.Request.QueryParamMatchers == nil {
+		e.Request.QueryParamMatchers = make(map[string]ValueMatcher)
+	}
+	e.Request.QueryParamMatchers[key] = ValueMatcher{Matches: pattern}
+	return e
+}
+
 // WithQueryParams adds multiple query parameter matchers at once.
 // Example: .WithQueryParams(map[string]string{"id": "123", "type": "user"})
 func (e *Expectation) WithQueryParams(params map[string]string) *Expectation {
@@ -104,6 +113,15 @@ func (e *Expectation) WithHeader(key, value string) *Expectation {
 	return e
 }
 
+// WithHeaderMatching adds a regex header matcher.
+func (e *Expectation) WithHeaderMatching(key, pattern string) *Expectation {
+	if e.Request.HeaderMatchers == nil {
+		e.Request.HeaderMatchers = make(map[string]ValueMatcher)
+	}
+	e.Request.HeaderMatchers[strings.ToLower(key)] = ValueMatcher{Matches: pattern}
+	return e
+}
+
 // WithHeaders adds multiple header matchers at once.
 // Keys are normalized to lowercase for case-insensitive matching.
 // Example: .WithHeaders(map[string]string{"Content-Type": "application/json", "X-API-Key": "secret"})
@@ -114,6 +132,31 @@ func (e *Expectation) WithHeaders(headers map[string]string) *Expectation {
 	for k, v := range headers {
 		e.Request.Headers[strings.ToLower(k)] = v
 	}
+	return e
+}
+
+// WithCookie adds an exact cookie matcher.
+func (e *Expectation) WithCookie(key, value string) *Expectation {
+	if e.Request.Cookies == nil {
+		e.Request.Cookies = make(map[string]ValueMatcher)
+	}
+	e.Request.Cookies[key] = ValueMatcher{EqualTo: value}
+	return e
+}
+
+// WithCookieMatching adds a regex cookie matcher.
+func (e *Expectation) WithCookieMatching(key, pattern string) *Expectation {
+	if e.Request.Cookies == nil {
+		e.Request.Cookies = make(map[string]ValueMatcher)
+	}
+	e.Request.Cookies[key] = ValueMatcher{Matches: pattern}
+	return e
+}
+
+// WithBasicAuth matches requests with HTTP Basic Authentication.
+func (e *Expectation) WithBasicAuth(username, password string) *Expectation {
+	e.Request.BasicAuthUsername = username
+	e.Request.BasicAuthPassword = password
 	return e
 }
 
@@ -183,6 +226,16 @@ func (e *Expectation) WithRequestPartialJSONBody(expected string) *Expectation {
 	return e
 }
 
+// WithRequestJSONField matches a JSON body field by simple dot path.
+// Example: .WithRequestJSONField("user.id", float64(42))
+func (e *Expectation) WithRequestJSONField(path string, expected interface{}) *Expectation {
+	if e.Request.JSONFields == nil {
+		e.Request.JSONFields = make(map[string]interface{})
+	}
+	e.Request.JSONFields[path] = expected
+	return e
+}
+
 // WithRequestBodyContains sets a matcher that checks if the request body contains the given substring.
 // Example: .WithRequestBodyContains("test")
 func (e *Expectation) WithRequestBodyContains(substring string) *Expectation {
@@ -203,6 +256,12 @@ func (e *Expectation) WithCustomBodyMatcher(matcher func([]byte) bool) *Expectat
 // Times sets how many times this expectation should be called.
 func (e *Expectation) Times(count int) *Expectation {
 	e.MaxCalls = &count
+	return e
+}
+
+// WithPriority sets matching priority. Lower numbers match first. Zero uses the default priority.
+func (e *Expectation) WithPriority(priority int) *Expectation {
+	e.Priority = priority
 	return e
 }
 
@@ -263,6 +322,24 @@ func (e *Expectation) AndRespondWithString(body string, statusCode int) *Expecta
 	return e.AndRespondWith([]byte(body), statusCode)
 }
 
+// AndRespondWithTemplate sets a Go text/template response body for the current response.
+func (e *Expectation) AndRespondWithTemplate(bodyTemplate string, statusCode int) *Expectation {
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	resp := e.getCurrentResponse()
+	resp.BodyTemplate = bodyTemplate
+	resp.StatusCode = statusCode
+	return e
+}
+
+// AndRespondWithFunc sets a custom response function for library users.
+func (e *Expectation) AndRespondWithFunc(responder func(http.ResponseWriter, *http.Request, []byte)) *Expectation {
+	resp := e.getCurrentResponse()
+	resp.Responder = responder
+	return e
+}
+
 // AndRespondFromFile sets the response body from a file and status code for the current response.
 func (e *Expectation) AndRespondFromFile(filePath string, statusCode int) *Expectation {
 	data, err := os.ReadFile(filePath)
@@ -282,6 +359,16 @@ func (e *Expectation) WithResponseHeader(key, value string) *Expectation {
 		resp.Headers = make(map[string]string)
 	}
 	resp.Headers[key] = value
+	return e
+}
+
+// WithResponseHeaderTemplate sets a Go text/template response header.
+func (e *Expectation) WithResponseHeaderTemplate(key, valueTemplate string) *Expectation {
+	resp := e.getCurrentResponse()
+	if resp.HeaderTemplates == nil {
+		resp.HeaderTemplates = make(map[string]string)
+	}
+	resp.HeaderTemplates[key] = valueTemplate
 	return e
 }
 
@@ -347,6 +434,11 @@ func (e *Expectation) matches(r *http.Request, body []byte) bool {
 			}
 		}
 	}
+	for paramKey, matcher := range e.Request.QueryParamMatchers {
+		if !valueMatches(r.URL.Query().Get(paramKey), matcher) {
+			return false
+		}
+	}
 	// --- Header Matching ---
 	for headerKey, expectedValue := range e.Request.Headers {
 		actualHeaderValue := r.Header.Get(headerKey)
@@ -354,10 +446,32 @@ func (e *Expectation) matches(r *http.Request, body []byte) bool {
 			return false
 		}
 	}
+	for headerKey, matcher := range e.Request.HeaderMatchers {
+		if !valueMatches(r.Header.Get(headerKey), matcher) {
+			return false
+		}
+	}
+	for cookieName, matcher := range e.Request.Cookies {
+		cookie, err := r.Cookie(cookieName)
+		if err != nil || !valueMatches(cookie.Value, matcher) {
+			return false
+		}
+	}
+	if e.Request.BasicAuthUsername != "" || e.Request.BasicAuthPassword != "" {
+		username, password, ok := r.BasicAuth()
+		if !ok || username != e.Request.BasicAuthUsername || password != e.Request.BasicAuthPassword {
+			return false
+		}
+	}
 	// --- Body Matching ---
 	if e.Request.BodyMatcher != nil {
-		return e.Request.BodyMatcher(body)
+		if !e.Request.BodyMatcher(body) {
+			return false
+		}
 	} else if len(e.Request.Body) > 0 && !reflect.DeepEqual(body, e.Request.Body) {
+		return false
+	}
+	if len(e.Request.JSONFields) > 0 && !jsonFieldsMatch(body, e.Request.JSONFields) {
 		return false
 	}
 	return true
@@ -398,6 +512,43 @@ func containsAll(actual, expected map[string]interface{}) bool {
 		}
 	}
 	return true
+}
+
+func valueMatches(actual string, matcher ValueMatcher) bool {
+	if matcher.Matches != "" {
+		matched, err := regexp.MatchString(matcher.Matches, actual)
+		return err == nil && matched
+	}
+	return actual == matcher.EqualTo
+}
+
+func jsonFieldsMatch(body []byte, expected map[string]interface{}) bool {
+	var actual interface{}
+	if err := json.Unmarshal(body, &actual); err != nil {
+		return false
+	}
+	for path, expectedValue := range expected {
+		actualValue, ok := valueAtDotPath(actual, path)
+		if !ok || !reflect.DeepEqual(actualValue, expectedValue) {
+			return false
+		}
+	}
+	return true
+}
+
+func valueAtDotPath(value interface{}, path string) (interface{}, bool) {
+	current := value
+	for _, part := range strings.Split(path, ".") {
+		object, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		current, ok = object[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
 }
 
 // AssertCalled checks if the expectation was called exactly `expected` times.

--- a/mappings.go
+++ b/mappings.go
@@ -1,0 +1,222 @@
+package moxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Mapping is moxy's native JSON representation for a mock endpoint.
+type Mapping struct {
+	Name      string            `json:"name,omitempty"`
+	Priority  int               `json:"priority,omitempty"`
+	Request   MappingRequest    `json:"request"`
+	Response  *MappingResponse  `json:"response,omitempty"`
+	Responses []MappingResponse `json:"responses,omitempty"`
+	Times     *int              `json:"times,omitempty"`
+}
+
+// MappingRequest defines request matching fields in JSON mapping files.
+type MappingRequest struct {
+	Method        string                  `json:"method"`
+	Path          string                  `json:"path,omitempty"`
+	PathPattern   string                  `json:"pathPattern,omitempty"`
+	Headers       map[string]string       `json:"headers,omitempty"`
+	HeaderMatches map[string]ValueMatcher `json:"headerMatches,omitempty"`
+	Query         map[string]string       `json:"query,omitempty"`
+	QueryMatches  map[string]ValueMatcher `json:"queryMatches,omitempty"`
+	Cookies       map[string]ValueMatcher `json:"cookies,omitempty"`
+	BasicAuth     *BasicAuth              `json:"basicAuth,omitempty"`
+	Body          string                  `json:"body,omitempty"`
+	JSONBody      json.RawMessage         `json:"jsonBody,omitempty"`
+	BodyContains  string                  `json:"bodyContains,omitempty"`
+	JSONFields    map[string]interface{}  `json:"jsonFields,omitempty"`
+}
+
+// BasicAuth defines username/password matching for mapping files.
+type BasicAuth struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// MappingResponse defines response fields in JSON mapping files.
+type MappingResponse struct {
+	Status          int               `json:"status,omitempty"`
+	Headers         map[string]string `json:"headers,omitempty"`
+	HeaderTemplates map[string]string `json:"headerTemplates,omitempty"`
+	Body            string            `json:"body,omitempty"`
+	BodyFile        string            `json:"bodyFile,omitempty"`
+	BodyTemplate    string            `json:"bodyTemplate,omitempty"`
+	Delay           string            `json:"delay,omitempty"`
+	Timeout         bool              `json:"timeout,omitempty"`
+}
+
+// LoadMappings loads all *.json mapping files from a directory.
+func (m *MockServer) LoadMappings(path string) error {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return fmt.Errorf("load mappings from %q: %w", path, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		fullPath := filepath.Join(path, entry.Name())
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			return fmt.Errorf("read mapping %q: %w", entry.Name(), err)
+		}
+		var mapping Mapping
+		if err := json.Unmarshal(data, &mapping); err != nil {
+			return fmt.Errorf("parse mapping %q: %w", entry.Name(), err)
+		}
+		if err := m.addMapping(mapping, filepath.Dir(fullPath)); err != nil {
+			return fmt.Errorf("add mapping %q: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+// AddMapping converts a native JSON mapping into an expectation.
+func (m *MockServer) AddMapping(mapping Mapping) error {
+	return m.addMapping(mapping, "")
+}
+
+func (m *MockServer) addMapping(mapping Mapping, baseDir string) error {
+	exp, err := mapping.toExpectation(baseDir)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.expectations = append(m.expectations, exp)
+	m.mappings = append(m.mappings, mapping)
+	m.sortExpectationsLocked()
+	return nil
+}
+
+// ToExpectation converts a mapping to the runtime expectation representation.
+func (mapping Mapping) ToExpectation() (*Expectation, error) {
+	return mapping.toExpectation("")
+}
+
+func (mapping Mapping) toExpectation(baseDir string) (*Expectation, error) {
+	if mapping.Request.Method == "" {
+		return nil, fmt.Errorf("mapping request.method is required")
+	}
+	if mapping.Request.Path == "" && mapping.Request.PathPattern == "" {
+		return nil, fmt.Errorf("mapping request.path or request.pathPattern is required")
+	}
+	if mapping.Response == nil && len(mapping.Responses) == 0 {
+		return nil, fmt.Errorf("mapping response or responses is required")
+	}
+
+	exp := NewExpectation().WithRequestMethod(mapping.Request.Method)
+	exp.Priority = mapping.Priority
+	exp.MaxCalls = mapping.Times
+
+	if mapping.Request.PathPattern != "" {
+		compiled, err := regexp.Compile(mapping.Request.PathPattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid request.pathPattern: %w", err)
+		}
+		exp.Request.PathPattern = compiled
+	} else {
+		exp.WithPath(mapping.Request.Path)
+		exp.Request.Path = mapping.Request.Path
+	}
+
+	for key, value := range mapping.Request.Headers {
+		exp.WithHeader(key, value)
+	}
+	if len(mapping.Request.HeaderMatches) > 0 {
+		exp.Request.HeaderMatchers = make(map[string]ValueMatcher, len(mapping.Request.HeaderMatches))
+		for key, matcher := range mapping.Request.HeaderMatches {
+			exp.Request.HeaderMatchers[strings.ToLower(key)] = matcher
+		}
+	}
+	for key, value := range mapping.Request.Query {
+		exp.WithQueryParam(key, value)
+	}
+	exp.Request.QueryParamMatchers = mapping.Request.QueryMatches
+	exp.Request.Cookies = mapping.Request.Cookies
+	exp.Request.JSONFields = mapping.Request.JSONFields
+	if mapping.Request.BasicAuth != nil {
+		exp.WithBasicAuth(mapping.Request.BasicAuth.Username, mapping.Request.BasicAuth.Password)
+	}
+	if mapping.Request.Body != "" {
+		exp.WithRequestBodyString(mapping.Request.Body)
+	}
+	if len(mapping.Request.JSONBody) > 0 {
+		exp.WithRequestJSONBody(string(mapping.Request.JSONBody))
+	}
+	if mapping.Request.BodyContains != "" {
+		exp.WithRequestBodyContains(mapping.Request.BodyContains)
+	}
+
+	responses := mapping.Responses
+	if mapping.Response != nil {
+		responses = []MappingResponse{*mapping.Response}
+	}
+	for i, response := range responses {
+		if i > 0 {
+			exp.NextResponse()
+		}
+		if err := applyMappingResponse(exp, response, baseDir); err != nil {
+			return nil, err
+		}
+	}
+	return exp, nil
+}
+
+func applyMappingResponse(exp *Expectation, response MappingResponse, baseDir string) error {
+	resp := exp.getCurrentResponse()
+	if response.Status == 0 {
+		resp.StatusCode = 200
+	} else {
+		resp.StatusCode = response.Status
+	}
+	resp.Headers = response.Headers
+	resp.HeaderTemplates = response.HeaderTemplates
+	resp.Body = []byte(response.Body)
+	resp.BodyTemplate = response.BodyTemplate
+	resp.TimeoutSimulation = response.Timeout
+
+	if response.BodyFile != "" {
+		bodyFile := response.BodyFile
+		if baseDir != "" && !filepath.IsAbs(bodyFile) {
+			bodyFile = filepath.Join(baseDir, bodyFile)
+		}
+		data, err := os.ReadFile(bodyFile)
+		if err != nil {
+			return fmt.Errorf("read response.bodyFile %q: %w", response.BodyFile, err)
+		}
+		resp.Body = data
+	}
+	if response.Delay != "" {
+		delay, err := time.ParseDuration(response.Delay)
+		if err != nil {
+			return fmt.Errorf("invalid response.delay %q: %w", response.Delay, err)
+		}
+		resp.Delay = delay
+	}
+	return nil
+}
+
+func (m *MockServer) sortExpectationsLocked() {
+	sort.SliceStable(m.expectations, func(i, j int) bool {
+		left, right := m.expectations[i].Priority, m.expectations[j].Priority
+		if left == 0 {
+			left = 5
+		}
+		if right == 0 {
+			right = 5
+		}
+		return left < right
+	})
+}

--- a/mappings_test.go
+++ b/mappings_test.go
@@ -1,0 +1,458 @@
+package moxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMappingTemplateAndRequestJournal(t *testing.T) {
+	ms := NewMockServer()
+	defer ms.Close()
+
+	err := ms.AddMapping(Mapping{
+		Priority: 1,
+		Request: MappingRequest{
+			Method: "POST",
+			Path:   "/users/{id}",
+			Headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			QueryMatches: map[string]ValueMatcher{
+				"trace": {Matches: "^abc-[0-9]+$"},
+			},
+			Cookies: map[string]ValueMatcher{
+				"session": {EqualTo: "s1"},
+			},
+			BasicAuth: &BasicAuth{Username: "user", Password: "pass"},
+			JSONFields: map[string]interface{}{
+				"profile.name": "Alice",
+			},
+		},
+		Response: &MappingResponse{
+			Status:       201,
+			BodyTemplate: `{"id":"{{index .PathVariables "id"}}","name":"{{jsonPath "profile.name"}}","trace":"{{first (index .Query "trace")}}"}`,
+			HeaderTemplates: map[string]string{
+				"X-User": `{{index .PathVariables "id"}}`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddMapping failed: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, ms.URL()+"/users/42?trace=abc-123", strings.NewReader(`{"profile":{"name":"Alice"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.SetBasicAuth("user", "pass")
+	req.AddCookie(&http.Cookie{Name: "session", Value: "s1"})
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ms.DefaultClient().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d: %s", resp.StatusCode, string(body))
+	}
+	if resp.Header.Get("X-User") != "42" {
+		t.Fatalf("expected templated response header")
+	}
+	if !strings.Contains(string(body), `"name":"Alice"`) {
+		t.Fatalf("expected templated response body, got %s", string(body))
+	}
+
+	requests := ms.GetRequests()
+	if len(requests) != 1 || !requests[0].Matched {
+		t.Fatalf("expected one matched request, got %+v", requests)
+	}
+	if ms.ExpectationCallCount(ms.expectations[0]) != 1 {
+		t.Fatalf("expected call count 1")
+	}
+}
+
+func TestLoadMappingsSequentialResponses(t *testing.T) {
+	dir := t.TempDir()
+	mappingFile := filepath.Join(dir, "status.json")
+	mapping := `{
+		"request": {"method": "GET", "path": "/status"},
+		"responses": [
+			{"status": 202, "body": "pending"},
+			{"status": 200, "body": "done"}
+		],
+		"times": 2
+	}`
+	if err := os.WriteFile(mappingFile, []byte(mapping), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ms := NewMockServer()
+	defer ms.Close()
+	if err := ms.LoadMappings(dir); err != nil {
+		t.Fatalf("LoadMappings failed: %v", err)
+	}
+
+	resp1, err := http.Get(ms.URL() + "/status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	_ = resp1.Body.Close()
+
+	resp2, err := http.Get(ms.URL() + "/status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+
+	if resp1.StatusCode != 202 || string(body1) != "pending" {
+		t.Fatalf("unexpected first response: %d %s", resp1.StatusCode, string(body1))
+	}
+	if resp2.StatusCode != 200 || string(body2) != "done" {
+		t.Fatalf("unexpected second response: %d %s", resp2.StatusCode, string(body2))
+	}
+	if err := ms.VerifyExpectations(); err != nil {
+		t.Fatalf("expected calls to satisfy times: %v", err)
+	}
+}
+
+func TestAdminAPI(t *testing.T) {
+	ms := NewMockServer()
+	defer ms.Close()
+
+	resp, err := http.Get(ms.URL() + "/__moxy/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected health 200, got %d", resp.StatusCode)
+	}
+	_ = resp.Body.Close()
+
+	mapping := Mapping{
+		Request:  MappingRequest{Method: "GET", Path: "/admin-added"},
+		Response: &MappingResponse{Status: 200, Body: "ok"},
+	}
+	data, _ := json.Marshal(mapping)
+	resp, err = http.Post(ms.URL()+"/__moxy/mappings", "application/json", bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected create 201, got %d: %s", resp.StatusCode, string(body))
+	}
+	_ = resp.Body.Close()
+
+	resp, err = http.Get(ms.URL() + "/admin-added")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if string(body) != "ok" {
+		t.Fatalf("expected admin mapping response, got %s", string(body))
+	}
+
+	resp, err = http.Get(ms.URL() + "/__moxy/requests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var requests []RequestRecord
+	if err := json.NewDecoder(resp.Body).Decode(&requests); err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if len(requests) != 1 || requests[0].Path != "/admin-added" {
+		t.Fatalf("expected one recorded mock request, got %+v", requests)
+	}
+}
+
+func TestMappingHelpersAndErrors(t *testing.T) {
+	t.Run("to expectation validation", func(t *testing.T) {
+		_, err := (Mapping{}).ToExpectation()
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+
+		_, err = (Mapping{
+			Request: MappingRequest{Method: "GET", PathPattern: "["},
+			Response: &MappingResponse{
+				Status: 200,
+				Body:   "ok",
+			},
+		}).ToExpectation()
+		if err == nil {
+			t.Fatal("expected invalid regex error")
+		}
+	})
+
+	t.Run("load mappings errors", func(t *testing.T) {
+		ms := NewMockServer()
+		defer ms.Close()
+
+		if err := ms.LoadMappings(filepath.Join(t.TempDir(), "missing")); err == nil {
+			t.Fatal("expected missing directory error")
+		}
+
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := ms.LoadMappings(dir); err == nil {
+			t.Fatal("expected invalid json error")
+		}
+	})
+
+	t.Run("response body file and delay errors", func(t *testing.T) {
+		_, err := (Mapping{
+			Request: MappingRequest{Method: "GET", Path: "/x"},
+			Response: &MappingResponse{
+				Status:   200,
+				BodyFile: "missing-file.json",
+			},
+		}).ToExpectation()
+		if err == nil {
+			t.Fatal("expected missing body file error")
+		}
+
+		_, err = (Mapping{
+			Request: MappingRequest{Method: "GET", Path: "/x"},
+			Response: &MappingResponse{
+				Status: 200,
+				Delay:  "not-a-duration",
+			},
+		}).ToExpectation()
+		if err == nil {
+			t.Fatal("expected invalid duration error")
+		}
+	})
+}
+
+func TestPublicHelpersAndTemplateFailures(t *testing.T) {
+	ms := NewMockServer()
+	defer ms.Close()
+
+	exp := NewExpectation().
+		WithRequestMethod("GET").
+		WithPath("/templated/{id}").
+		WithPathVariables(map[string]string{"id": "7"}).
+		WithQueryParamMatching("trace", "^t-[0-9]+$").
+		WithHeaderMatching("X-Mode", "^prod|test$").
+		WithCookieMatching("session", "^s[0-9]+$").
+		WithPriority(1).
+		WithResponseHeaderTemplate("X-ID", `{{index .PathVariables "id"}}`).
+		AndRespondWithTemplate(`{"id":"{{index .PathVariables "id"}}","trace":"{{first (index .Query "trace")}}"}`, 200)
+	ms.AddExpectation(exp)
+
+	req, err := http.NewRequest(http.MethodGet, ms.URL()+"/templated/7?trace=t-123", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Mode", "prod")
+	req.AddCookie(&http.Cookie{Name: "session", Value: "s9"})
+
+	resp, err := ms.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.Header.Get("X-ID") != "7" || !strings.Contains(string(body), `"trace":"t-123"`) {
+		t.Fatalf("unexpected templated response: status=%d header=%q body=%s", resp.StatusCode, resp.Header.Get("X-ID"), string(body))
+	}
+
+	all := ms.AllRequests()
+	if len(all) != 1 {
+		t.Fatalf("expected one request in AllRequests, got %d", len(all))
+	}
+	matched := true
+	found := ms.FindRequests(RequestFilter{Method: http.MethodGet, Path: "/templated/7", Matched: &matched})
+	if len(found) != 1 {
+		t.Fatalf("expected FindRequests match, got %d", len(found))
+	}
+	ms.ClearRequests()
+	if len(ms.GetRequests()) != 0 || len(ms.GetUnmatchedRequests()) != 0 {
+		t.Fatal("expected ClearRequests to empty journal")
+	}
+
+	t.Run("function responder", func(t *testing.T) {
+		funcServer := NewMockServer()
+		defer funcServer.Close()
+
+		funcServer.AddExpectation(NewExpectation().
+			WithRequestMethod("POST").
+			WithPath("/func").
+			AndRespondWithFunc(func(w http.ResponseWriter, r *http.Request, body []byte) {
+				w.Header().Set("X-Body", string(body))
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = w.Write([]byte("handled"))
+			}))
+
+		resp, err := http.Post(funcServer.URL()+"/func", "text/plain", strings.NewReader("payload"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusAccepted || resp.Header.Get("X-Body") != "payload" || string(body) != "handled" {
+			t.Fatalf("unexpected function response: %d %q %s", resp.StatusCode, resp.Header.Get("X-Body"), string(body))
+		}
+	})
+
+	t.Run("template render failures", func(t *testing.T) {
+		badTemplateServer := NewMockServer()
+		defer badTemplateServer.Close()
+		badTemplateServer.AddExpectation(NewExpectation().
+			WithRequestMethod("GET").
+			WithPath("/bad-template").
+			AndRespondWithTemplate(`{{`, 200))
+
+		resp, err := http.Get(badTemplateServer.URL() + "/bad-template")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected template parse failure to return 500, got %d", resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+
+		badHeaderServer := NewMockServer()
+		defer badHeaderServer.Close()
+		badHeaderServer.AddExpectation(NewExpectation().
+			WithRequestMethod("GET").
+			WithPath("/bad-header").
+			WithResponseHeaderTemplate("X-Bad", `{{`).
+			AndRespondWithString("ok", 200))
+
+		resp, err = http.Get(badHeaderServer.URL() + "/bad-header")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK || resp.Header.Get("X-Bad") != "" {
+			t.Fatalf("expected bad header template to be skipped, got status=%d header=%q", resp.StatusCode, resp.Header.Get("X-Bad"))
+		}
+		_ = resp.Body.Close()
+	})
+}
+
+func TestServerEngineHelpersAndAdminBranches(t *testing.T) {
+	engine := NewMockServerEngine(&Config{
+		Protocol: HTTPS,
+		TLSConfig: &TLSOptions{
+			RequireClientCert:  true,
+			SkipClientVerify:   true,
+			InsecureSkipVerify: true,
+		},
+	})
+	if engine.URL() != "" {
+		t.Fatal("expected engine URL to be empty before httptest startup")
+	}
+	if engine.ServerTLSConfig() == nil {
+		t.Fatal("expected ServerTLSConfig")
+	}
+	engine.Use(func(next http.Handler) http.Handler { return next })
+
+	t.Run("admin delete and reset", func(t *testing.T) {
+		ms := NewMockServer()
+		defer ms.Close()
+
+		_, _ = http.Get(ms.URL() + "/missing")
+
+		req, _ := http.NewRequest(http.MethodDelete, ms.URL()+"/__moxy/requests", nil)
+		resp, err := ms.DefaultClient().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected delete requests 200, got %d", resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+
+		if err := ms.AddMapping(Mapping{
+			Request:  MappingRequest{Method: "GET", Path: "/x"},
+			Response: &MappingResponse{Status: 200, Body: "ok"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		req, _ = http.NewRequest(http.MethodDelete, ms.URL()+"/__moxy/mappings", nil)
+		resp, err = ms.DefaultClient().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected delete mappings 200, got %d", resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+
+		req, _ = http.NewRequest(http.MethodPost, ms.URL()+"/__moxy/reset", nil)
+		resp, err = ms.DefaultClient().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected reset 200, got %d", resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+
+		resp, err = http.Get(ms.URL() + "/__moxy/unknown")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("expected unknown admin endpoint 404, got %d", resp.StatusCode)
+		}
+		_ = resp.Body.Close()
+	})
+
+	t.Run("error string and remove expectation false", func(t *testing.T) {
+		errObj := &ExpectationError{Message: "boom", Details: []string{"a", "b"}}
+		msg := errObj.Error()
+		if !strings.Contains(msg, "boom") || !strings.Contains(msg, "a") || !strings.Contains(msg, "b") {
+			t.Fatalf("unexpected error string: %s", msg)
+		}
+
+		ms := NewMockServer()
+		defer ms.Close()
+		if ms.RemoveExpectation(NewExpectation()) {
+			t.Fatal("expected remove to return false for unknown expectation")
+		}
+	})
+}
+
+func TestAssertionFailureAndRequestHelpers(t *testing.T) {
+	e := NewExpectation().WithRequestMethod("GET").WithPath("/x")
+	if err := e.AssertCalled(1); err == nil {
+		t.Fatal("expected AssertCalled failure")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/simple", nil)
+	if got := capturePathVariables(e, req.URL.Path); len(got) != 0 {
+		t.Fatalf("expected no path captures, got %+v", got)
+	}
+}
+
+func TestRenderTemplateHelperFailurePath(t *testing.T) {
+	_, err := renderTemplate(`{{index .PathVariables "id"`, templateData{})
+	if err == nil {
+		t.Fatal("expected template parse error")
+	}
+
+	_, ok := valueAtDotPath(errors.New("x"), "field")
+	if ok {
+		t.Fatal("expected valueAtDotPath failure for non-object")
+	}
+}

--- a/mock_server.go
+++ b/mock_server.go
@@ -1,14 +1,18 @@
 package moxy
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
+	"text/template"
 	"time"
 )
 
@@ -49,21 +53,33 @@ func NewMockServer() *MockServer {
 
 // NewMockServerWithConfig initializes a new MockServer with custom configuration.
 func NewMockServerWithConfig(customConfig *Config) *MockServer {
-	config := mergeWithDefaults(customConfig)
-	ms := &MockServer{
-		logger: log.New(os.Stdout, "[MockServer] ", log.LstdFlags|log.Lshortfile),
-		config: *config,
-	}
+	ms := NewMockServerEngine(customConfig)
+	config := &ms.config
 
 	if config.Protocol == HTTPS {
-		server := httptest.NewUnstartedServer(http.HandlerFunc(ms.handler))
+		server := httptest.NewUnstartedServer(ms.Handler())
 		server.TLS = buildTLSConfig(config.TLSConfig)
 		server.StartTLS()
 		ms.server = server
 	} else {
-		ms.server = httptest.NewServer(http.HandlerFunc(ms.handler))
+		ms.server = httptest.NewServer(ms.Handler())
 	}
 	return ms
+}
+
+// NewMockServerEngine creates a MockServer without starting an httptest.Server.
+// This is useful for standalone binary mode where the caller owns the listener.
+func NewMockServerEngine(customConfig *Config) *MockServer {
+	config := mergeWithDefaults(customConfig)
+	return &MockServer{
+		logger: log.New(os.Stdout, "[MockServer] ", log.LstdFlags|log.Lshortfile),
+		config: *config,
+	}
+}
+
+// ServerTLSConfig returns the server TLS config for standalone HTTPS mode.
+func (m *MockServer) ServerTLSConfig() *tls.Config {
+	return buildTLSConfig(m.config.TLSConfig)
 }
 
 // buildTLSConfig builds a *tls.Config from TLSOptions.
@@ -120,11 +136,16 @@ func (m *MockServer) WithUnmatchedResponder(
 
 // Close shuts down the mock server.
 func (m *MockServer) Close() {
-	m.server.Close()
+	if m.server != nil {
+		m.server.Close()
+	}
 }
 
 // URL returns the base URL of the mock server.
 func (m *MockServer) URL() string {
+	if m.server == nil {
+		return ""
+	}
 	return m.server.URL
 }
 
@@ -133,6 +154,7 @@ func (m *MockServer) AddExpectation(e *Expectation) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.expectations = append(m.expectations, e)
+	m.sortExpectationsLocked()
 }
 
 // ClearExpectations removes all registered expectations.
@@ -140,6 +162,7 @@ func (m *MockServer) ClearExpectations() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.expectations = m.expectations[:0]
+	m.mappings = m.mappings[:0]
 }
 
 // RemoveExpectation removes a specific expectation. Returns true if found and removed.
@@ -155,6 +178,14 @@ func (m *MockServer) RemoveExpectation(e *Expectation) bool {
 	return false
 }
 
+// Handler returns the HTTP handler used by both httptest and standalone modes.
+func (m *MockServer) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/__moxy/", m.adminHandler)
+	mux.HandleFunc("/", m.handler)
+	return mux
+}
+
 // GetUnmatchedRequests returns a copy of all unmatched requests.
 func (m *MockServer) GetUnmatchedRequests() []UnmatchedRequest {
 	m.mu.RLock()
@@ -164,10 +195,52 @@ func (m *MockServer) GetUnmatchedRequests() []UnmatchedRequest {
 	return result
 }
 
+// GetRequests returns a copy of all received requests.
+func (m *MockServer) GetRequests() []RequestRecord {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]RequestRecord, len(m.requests))
+	copy(result, m.requests)
+	return result
+}
+
+// AllRequests is an alias for GetRequests.
+func (m *MockServer) AllRequests() []RequestRecord {
+	return m.GetRequests()
+}
+
+// FindRequests returns requests matching the supplied filter.
+func (m *MockServer) FindRequests(filter RequestFilter) []RequestRecord {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []RequestRecord
+	for _, req := range m.requests {
+		if filter.Method != "" && req.Method != filter.Method {
+			continue
+		}
+		if filter.Path != "" && req.Path != filter.Path {
+			continue
+		}
+		if filter.Matched != nil && req.Matched != *filter.Matched {
+			continue
+		}
+		result = append(result, req)
+	}
+	return result
+}
+
 // ClearUnmatchedRequests clears the history of unmatched requests.
 func (m *MockServer) ClearUnmatchedRequests() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.unmatchedRequests = m.unmatchedRequests[:0]
+}
+
+// ClearRequests clears the full request journal and unmatched request history.
+func (m *MockServer) ClearRequests() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requests = m.requests[:0]
 	m.unmatchedRequests = m.unmatchedRequests[:0]
 }
 
@@ -214,11 +287,14 @@ func (m *MockServer) handler(w http.ResponseWriter, r *http.Request) {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	record := requestRecordFrom(r, body)
 	for _, exp := range m.expectations {
 		if exp.matches(r, body) {
 			if exp.MaxCalls != nil && exp.InvocationCount >= *exp.MaxCalls {
 				continue
 			}
+			record.Matched = true
+			m.requests = append(m.requests, record)
 			exp.InvocationCount++
 			resp := ResponseDefinition{}
 			// If user configured responses, pick the right one
@@ -236,12 +312,30 @@ func (m *MockServer) handler(w http.ResponseWriter, r *http.Request) {
 			if resp.Delay > 0 {
 				time.Sleep(resp.Delay)
 			}
-			// Write headers
+			if resp.Responder != nil {
+				resp.Responder(w, r, body)
+				return
+			}
+			templateData := newTemplateData(r, body, exp)
+			renderedHeaders := renderHeaderTemplates(resp, templateData, m.logger)
 			for key, value := range resp.Headers {
 				w.Header().Set(key, value)
 			}
+			for key, value := range renderedHeaders {
+				w.Header().Set(key, value)
+			}
+			responseBody := resp.Body
+			if resp.BodyTemplate != "" {
+				renderedBody, err := renderTemplate(resp.BodyTemplate, templateData)
+				if err != nil {
+					m.logger.Printf("Failed to render response template: %v", err)
+					http.Error(w, "failed to render response template", http.StatusInternalServerError)
+					return
+				}
+				responseBody = []byte(renderedBody)
+			}
 			w.WriteHeader(resp.StatusCode)
-			if _, err := w.Write(resp.Body); err != nil {
+			if _, err := w.Write(responseBody); err != nil {
 				m.logger.Printf("Failed to write response: %v", err)
 			}
 			if m.config.VerboseLogging {
@@ -252,6 +346,7 @@ func (m *MockServer) handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// No match -> record unmatched
+	m.requests = append(m.requests, record)
 	unmatched := UnmatchedRequest{
 		Method:    r.Method,
 		URL:       r.URL.RequestURI(),
@@ -296,10 +391,20 @@ func (m *MockServer) DefaultClient() *http.Client {
 	return &http.Client{Transport: transport}
 }
 
+// Client is an alias for DefaultClient.
+func (m *MockServer) Client() *http.Client {
+	return m.DefaultClient()
+}
+
 // mTLSClient returns an *http.Client configured for mutual TLS.
 // It uses the TLSOptions from the server. The caller provides client certificates and RootCAs.
 // This is useful for testing mTLS scenarios where the server verifies the client certificate.
 func (m *MockServer) mTLSClient(clientCerts []tls.Certificate, rootCAs *x509.CertPool) *http.Client {
+	return m.MTLSClient(clientCerts, rootCAs)
+}
+
+// MTLSClient returns an *http.Client configured for mutual TLS.
+func (m *MockServer) MTLSClient(clientCerts []tls.Certificate, rootCAs *x509.CertPool) *http.Client {
 	tlsConfig := &tls.Config{
 		Certificates: clientCerts, // allow multiple client certs
 		RootCAs:      rootCAs,     // trust server cert
@@ -322,12 +427,167 @@ func (m *MockServer) mTLSClient(clientCerts []tls.Certificate, rootCAs *x509.Cer
 
 // Use adds middleware to the mock server (applied to all requests).
 func (m *MockServer) Use(middleware func(http.Handler) http.Handler) {
-	m.server.Config.Handler = middleware(m.server.Config.Handler)
+	if m.server != nil {
+		m.server.Config.Handler = middleware(m.server.Config.Handler)
+	}
 }
+
+// ExpectationCallCount returns how many times an expectation matched.
+func (m *MockServer) ExpectationCallCount(e *Expectation) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return e.InvocationCount
+}
+
 func (e *ExpectationError) Error() string {
 	result := e.Message
 	for _, detail := range e.Details {
 		result += "\n  " + detail
 	}
 	return result
+}
+
+func requestRecordFrom(r *http.Request, body []byte) RequestRecord {
+	cookies := make(map[string]string)
+	for _, cookie := range r.Cookies() {
+		cookies[cookie.Name] = cookie.Value
+	}
+	return RequestRecord{
+		Method:    r.Method,
+		URL:       r.URL.RequestURI(),
+		Path:      r.URL.Path,
+		Query:     map[string][]string(r.URL.Query()),
+		Headers:   map[string][]string(r.Header),
+		Cookies:   cookies,
+		Body:      string(body),
+		Timestamp: time.Now(),
+	}
+}
+
+type templateData struct {
+	Method        string
+	Path          string
+	PathVariables map[string]string
+	Query         map[string][]string
+	Headers       map[string][]string
+	Cookies       map[string]string
+	Body          string
+	JSON          interface{}
+}
+
+func newTemplateData(r *http.Request, body []byte, exp *Expectation) templateData {
+	var jsonBody interface{}
+	_ = json.Unmarshal(body, &jsonBody)
+	data := templateData{
+		Method:        r.Method,
+		Path:          r.URL.Path,
+		PathVariables: capturePathVariables(exp, r.URL.Path),
+		Query:         map[string][]string(r.URL.Query()),
+		Headers:       map[string][]string(r.Header),
+		Cookies:       make(map[string]string),
+		Body:          string(body),
+		JSON:          jsonBody,
+	}
+	for _, cookie := range r.Cookies() {
+		data.Cookies[cookie.Name] = cookie.Value
+	}
+	return data
+}
+
+func capturePathVariables(exp *Expectation, path string) map[string]string {
+	result := make(map[string]string)
+	if exp.Request.PathPattern == nil {
+		return result
+	}
+	matches := exp.Request.PathPattern.FindStringSubmatch(path)
+	if matches == nil {
+		return result
+	}
+	for i, name := range exp.Request.PathPattern.SubexpNames() {
+		if i > 0 && name != "" {
+			result[name] = matches[i]
+		}
+	}
+	return result
+}
+
+func renderHeaderTemplates(resp ResponseDefinition, data templateData, logger *log.Logger) map[string]string {
+	result := make(map[string]string)
+	for key, valueTemplate := range resp.HeaderTemplates {
+		value, err := renderTemplate(valueTemplate, data)
+		if err != nil {
+			logger.Printf("Failed to render response header template %s: %v", key, err)
+			continue
+		}
+		result[key] = value
+	}
+	return result
+}
+
+func renderTemplate(source string, data templateData) (string, error) {
+	tpl, err := template.New("moxy-response").Funcs(template.FuncMap{
+		"first": func(values []string) string {
+			if len(values) == 0 {
+				return ""
+			}
+			return values[0]
+		},
+		"jsonPath": func(path string) interface{} {
+			value, _ := valueAtDotPath(data.JSON, path)
+			return value
+		},
+	}).Parse(source)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func (m *MockServer) adminHandler(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimSuffix(r.URL.Path, "/")
+	w.Header().Set("Content-Type", "application/json")
+
+	switch {
+	case r.Method == http.MethodGet && path == "/__moxy/health":
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case r.Method == http.MethodGet && path == "/__moxy/mappings":
+		m.mu.RLock()
+		mappings := append([]Mapping(nil), m.mappings...)
+		m.mu.RUnlock()
+		writeJSON(w, http.StatusOK, mappings)
+	case r.Method == http.MethodPost && path == "/__moxy/mappings":
+		var mapping Mapping
+		if err := json.NewDecoder(r.Body).Decode(&mapping); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if err := m.AddMapping(mapping); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusCreated, mapping)
+	case r.Method == http.MethodDelete && path == "/__moxy/mappings":
+		m.ClearExpectations()
+		writeJSON(w, http.StatusOK, map[string]string{"status": "cleared"})
+	case r.Method == http.MethodGet && path == "/__moxy/requests":
+		writeJSON(w, http.StatusOK, m.GetRequests())
+	case r.Method == http.MethodDelete && path == "/__moxy/requests":
+		m.ClearRequests()
+		writeJSON(w, http.StatusOK, map[string]string{"status": "cleared"})
+	case r.Method == http.MethodPost && path == "/__moxy/reset":
+		m.ClearExpectations()
+		m.ClearRequests()
+		writeJSON(w, http.StatusOK, map[string]string{"status": "reset"})
+	default:
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown moxy admin endpoint"})
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, value interface{}) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
 }

--- a/types.go
+++ b/types.go
@@ -24,21 +24,36 @@ type ResponseDefinition struct {
 	StatusCode        int
 	Body              []byte
 	Headers           map[string]string
+	BodyTemplate      string
+	HeaderTemplates   map[string]string
+	Responder         func(http.ResponseWriter, *http.Request, []byte)
 	Delay             time.Duration // optional delay before sending response
 	TimeoutSimulation bool          // if true, server never responds
 }
 
+// ValueMatcher supports either exact or regex-based matching.
+type ValueMatcher struct {
+	EqualTo string `json:"equalTo,omitempty"`
+	Matches string `json:"matches,omitempty"`
+}
+
 // RequestExpectation defines the expected request structure.
 type RequestExpectation struct {
-	Method        string
-	Path          string
-	PathPattern   *regexp.Regexp
-	PathVariables map[string]string
-	Body          []byte
-	BodyMatcher   func([]byte) bool
-	QueryParams   map[string]string
-	Headers       map[string]string // stored as lowercase keys for case-insensitive matching
-	BodyFromFile  bool
+	Method             string
+	Path               string
+	PathPattern        *regexp.Regexp
+	PathVariables      map[string]string
+	Body               []byte
+	BodyMatcher        func([]byte) bool
+	QueryParams        map[string]string
+	QueryParamMatchers map[string]ValueMatcher
+	Headers            map[string]string // stored as lowercase keys for case-insensitive matching
+	HeaderMatchers     map[string]ValueMatcher
+	Cookies            map[string]ValueMatcher
+	BasicAuthUsername  string
+	BasicAuthPassword  string
+	JSONFields         map[string]interface{}
+	BodyFromFile       bool
 }
 
 // Expectation defines a mock expectation for HTTP requests.
@@ -50,17 +65,40 @@ type Expectation struct {
 	InvocationCount     int
 	MaxCalls            *int // nil means unlimited
 	NextResponseIndex   int  // tracks which response to return next
+	Priority            int
 }
 
 // MockServer represents a lightweight HTTP mock server for testing HTTP clients.
 type MockServer struct {
 	server             *httptest.Server
 	expectations       []*Expectation
+	mappings           []Mapping
+	requests           []RequestRecord
 	unmatchedRequests  []UnmatchedRequest
 	mu                 sync.RWMutex
 	logger             *log.Logger
 	config             Config
 	unmatchedResponder func(w http.ResponseWriter, r *http.Request, req UnmatchedRequest)
+}
+
+// RequestRecord represents any request received by the mock server.
+type RequestRecord struct {
+	Method    string              `json:"method"`
+	URL       string              `json:"url"`
+	Path      string              `json:"path"`
+	Query     map[string][]string `json:"query"`
+	Headers   map[string][]string `json:"headers"`
+	Cookies   map[string]string   `json:"cookies"`
+	Body      string              `json:"body"`
+	Matched   bool                `json:"matched"`
+	Timestamp time.Time           `json:"timestamp"`
+}
+
+// RequestFilter is used to find recorded requests.
+type RequestFilter struct {
+	Method  string
+	Path    string
+	Matched *bool
 }
 
 // UnmatchedRequest represents a request that didn't match any expectations
@@ -76,6 +114,8 @@ type UnmatchedRequest struct {
 type Config struct {
 	Protocol               Protocol    // HTTP or HTTPS
 	TLSConfig              *TLSOptions // Server's custom TLS config
+	Host                   string      // Host for standalone binary mode
+	Port                   int         // Port for standalone binary mode
 	UnmatchedStatusCode    int         // Status code for unmatched requests (default: 418)
 	UnmatchedStatusMessage string      // Status message for unmatched requests (default: "Unmatched Request")
 	LogUnmatched           bool        // Whether to log unmatched requests (default: true)


### PR DESCRIPTION
## Summary

This PR expands moxy from an in-process Go test helper into a more complete Go-native HTTP mock server while keeping the existing library workflow intact.

It adds:

- richer request matching for cookies, basic auth, regex headers/query params, JSON fields, and priority
- dynamic responses using Go templates and custom responder functions
- a full request journal for matched and unmatched requests
- native JSON mapping support
- runtime admin endpoints under `/__moxy`
- a standalone `moxy` CLI
- expanded tests for the new library and CLI behavior
- README and proposed-changes documentation updates

## Why

Earlier, moxy already worked well for Go tests that define expectations in code. These changes make it more useful for Go service teams that also want file-based mock definitions, runtime inspection, local mock-server usage, and better request verification.

## Review Notes

The main areas worth reviewing carefully are:

- expectation ordering now that `Priority` exists
- whether `ClearExpectations()` should also clear loaded mappings
- whether `/__moxy` is the desired admin API namespace
- whether the standalone CLI belongs in this repository now or should remain optional

## Squashed Commit Details

This squashed PR includes the logical changes from:

- `feat: add richer request matching and dynamic responses`
- `feat: add native JSON mapping support`
- `feat: add standalone moxy CLI`
- `test: cover mappings, journal, admin API, and CLI`
- `docs: add proposed changes review note`
- `docs: update README for new moxy features`

## Verification

Ran successfully:

```bash
go test ./... -race -coverprofile=coverage.out -v
go build -o /tmp/moxy-test-build ./cmd/moxy